### PR TITLE
Add .gitignore for common artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Node dependencies
+node_modules/
+
+# Build output
+/dist/
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.idea/
+.vscode/
+
+# Temporary files
+*.tmp
+*.log
+


### PR DESCRIPTION
## Summary
- add a `.gitignore` file to keep build artifacts and OS files out of version control

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68680509b8ec833096897ca18cda142a