### PR TITLE
Replace Tailwind @apply in buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,11 +58,24 @@
 
         /* Primary Button with Shine Effect */
         .btn-primary {
-            @apply relative overflow-hidden bg-gradient-to-r from-sky-600 to-blue-700 text-white px-8 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 ease-in-out font-semibold text-lg;
+            position: relative;
+            overflow: hidden;
+            background: linear-gradient(to right, #0284c7, #1d4ed8);
+            color: #ffffff;
+            padding: 0.75rem 2rem;
+            border-radius: 0.75rem;
+            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1),
+                        0 4px 6px -4px rgba(0, 0, 0, 0.1);
+            transition: all 0.3s ease-in-out;
+            font-weight: 600;
+            font-size: 1.125rem;
+            line-height: 1.75rem;
             z-index: 1;
         }
         .btn-primary:hover {
             transform: translateY(-2px);
+            box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
+                        0 10px 10px -5px rgba(0, 0, 0, 0.04);
         }
         .btn-primary::after {
             content: '';
@@ -82,7 +95,22 @@
 
         /* Secondary Button */
         .btn-secondary {
-            @apply bg-gray-700 text-gray-200 px-8 py-3 rounded-xl shadow-lg hover:bg-gray-600 transition duration-300 ease-in-out font-semibold text-lg;
+            background-color: #374151;
+            color: #e5e7eb;
+            padding: 0.75rem 2rem;
+            border-radius: 0.75rem;
+            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1),
+                        0 4px 6px -4px rgba(0, 0, 0, 0.1);
+            transition: background-color 0.3s ease-in-out,
+                        box-shadow 0.3s ease-in-out;
+            font-weight: 600;
+            font-size: 1.125rem;
+            line-height: 1.75rem;
+        }
+        .btn-secondary:hover {
+            background-color: #4b5563;
+            box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
+                        0 10px 10px -5px rgba(0, 0, 0, 0.04);
         }
 
         /* Custom height for hero section to account for fixed nav */
@@ -395,7 +423,7 @@
                     <div class="portfolio-card-overlay">
                         <h3 class="text-white">Chassis Optimization</h3>
                         <p class="text-white">FEA-driven design for weight reduction and rigidity.</p>
-                        <a href="#" class="btn-secondary text-white bg-transparent border border-white hover:bg-white hover:text-sky-600 px-4 py-2 text-sm rounded-lg">View Details</a>
+                        <a href="#" class="text-white bg-transparent border border-white hover:bg-white hover:text-sky-600 px-4 py-2 text-sm rounded-lg transition duration-300 ease-in-out shadow-lg">View Details</a>
                     </div>
                 </div>
                 <!-- Project 2 -->
@@ -410,7 +438,7 @@
                     <div class="portfolio-card-overlay">
                         <h3 class="text-white">Aerospace Analysis</h3>
                         <p class="text-white">Ensuring safety and longevity through advanced stress analysis.</p>
-                        <a href="#" class="btn-secondary text-white bg-transparent border border-white hover:bg-white hover:text-sky-600 px-4 py-2 text-sm rounded-lg">View Details</a>
+                        <a href="#" class="text-white bg-transparent border border-white hover:bg-white hover:text-sky-600 px-4 py-2 text-sm rounded-lg transition duration-300 ease-in-out shadow-lg">View Details</a>
                     </div>
                 </div>
                 <!-- Project 3 -->
@@ -425,7 +453,7 @@
                     <div class="portfolio-card-overlay">
                         <h3 class="text-white">Wind Turbine Optimization</h3>
                         <p class="text-white">Innovative blade design for enhanced energy capture.</p>
-                        <a href="#" class="btn-secondary text-white bg-transparent border border-white hover:bg-white hover:text-sky-600 px-4 py-2 text-sm rounded-lg">View Details</a>
+                        <a href="#" class="text-white bg-transparent border border-white hover:bg-white hover:text-sky-600 px-4 py-2 text-sm rounded-lg transition duration-300 ease-in-out shadow-lg">View Details</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- convert `.btn-primary` and `.btn-secondary` styles from `@apply` to regular CSS
- adjust overlay links to use Tailwind classes directly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868050ade3c833089e2023523accf3e