### PR TITLE
Fix typewriter animation length

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,9 @@
             white-space: nowrap; /* Keeps the content on a single line */
             border-right: .15em solid white; /* The typewriter cursor */
             animation:
-                typing 3.5s steps(40, end),
+                /* Adjust steps to the length of the heading text so the
+                   typewriter animation completes fully */
+                typing 3.5s steps(57, end),
                 blink-caret .75s step-end infinite;
         }
 


### PR DESCRIPTION
## Summary
- adjust typing animation steps so the headline text is fully typed

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68680866658883308c716d73df150904